### PR TITLE
Add temporal constraints law to core principles

### DIFF
--- a/docs/core-principles/index.md
+++ b/docs/core-principles/index.md
@@ -48,6 +48,7 @@ graph TB
     |-----|---------|
     | [Correlated Failure](laws/correlated-failure.md) | Failures cascade across system boundaries |
     | [Asynchronous Reality](laws/asynchronous-reality.md) | Networks are inherently unreliable and slow |
+    | [Temporal Constraints](laws/temporal-constraints.md) | Perfect time synchronization is unattainable |
     | [Emergent Chaos](laws/emergent-chaos.md) | Complexity emerges from simple interactions |
     | [Multidimensional Optimization](laws/multidimensional-optimization.md) | Every trade-off has multiple dimensions |
     | [Distributed Knowledge](laws/distributed-knowledge.md) | Perfect knowledge is physically impossible |

--- a/docs/core-principles/laws.md
+++ b/docs/core-principles/laws.md
@@ -9,37 +9,37 @@ These laws are not guidelines or best practices - they are immutable constraints
 
 ## The Laws
 
-1. **[The Inevitability of Failure](correlated-failure.md)**
+1. **[The Inevitability of Failure](laws/correlated-failure.md)**
    - Components will fail
    - Failures cascade and correlate
    - Perfect reliability is impossible
 
-2. **[The Economics of Scale](economic-reality.md)**
+2. **[The Economics of Scale](laws/economic-reality.md)**
    - Resources are finite
    - Cost drives architectural decisions
    - Trade-offs are inevitable
 
-3. **[The Constraints of Time](temporal-constraints.md)**
+3. **[The Constraints of Time](laws/temporal-constraints.md)**
    - Perfect synchronization is impossible
    - Time ordering is relative
    - Causality requires explicit tracking
 
-4. **[The Reality of Networks](asynchronous-reality.md)**
+4. **[The Reality of Networks](laws/asynchronous-reality.md)**
    - Networks partition
    - Latency is non-zero
    - Bandwidth is limited
 
-5. **[The Human Factor](cognitive-load.md)**
+5. **[The Human Factor](laws/cognitive-load.md)**
    - Humans have cognitive limits
    - Complexity must be managed
    - Operations require human understanding
 
-6. **[The Nature of Knowledge](distributed-knowledge.md)**
+6. **[The Nature of Knowledge](laws/distributed-knowledge.md)**
    - Global state is unknowable
    - Information propagates slowly
    - Decisions use partial information
 
-7. **[The Emergence of Chaos](emergent-chaos.md)**
+7. **[The Emergence of Chaos](laws/emergent-chaos.md)**
    - Complex systems exhibit emergent behavior
    - Small changes have large effects
    - Predictability decreases with scale

--- a/docs/core-principles/laws/index.md
+++ b/docs/core-principles/laws/index.md
@@ -65,12 +65,20 @@ Choose your learning intensity:
     *📖 Study time: 2-3 hours | 🧠 Difficulty: Low | 💼 Immediate impact: Very High*
 
 - **[Law of Asynchronous Reality](asynchronous-reality.md)**
-    
+
     ---
-    
+
     Perfect synchronization is impossible in distributed systems
-    
+
     *📖 Study time: 4-5 hours | 🧠 Difficulty: High | 💼 Immediate impact: High*
+
+- **[Law of Temporal Constraints](temporal-constraints.md)**
+
+    ---
+
+    Clock drift and relativistic limits prevent a single global timeline
+
+    *📖 Study time: 3-4 hours | 🧠 Difficulty: Medium | 💼 Immediate impact: High*
 
 - **[Law of Multidimensional Optimization](multidimensional-optimization.md)**
     

--- a/docs/core-principles/laws/temporal-constraints.md
+++ b/docs/core-principles/laws/temporal-constraints.md
@@ -1,0 +1,25 @@
+---
+title: Temporal Constraints
+description: Why perfect time synchronization is impossible in distributed systems
+---
+
+# Temporal Constraints
+
+Time in distributed systems is both essential and unreliable. Clocks drift, messages arrive out of order, and no global reference exists. These limitations form the temporal constraints that every architecture must respect.
+
+## Clock Drift and Skew
+
+Even atomic clocks diverge over time. Network Time Protocol (NTP) can reduce error but never eliminates it. Nodes must assume their local clocks are approximate and handle skew explicitly.
+
+## Relative Ordering
+
+Without a trusted global clock, events are ordered relative to one another. Logical clocks, vector clocks, and hybrid logical clocks provide partial ordering, but causality still requires explicit tracking.
+
+## Practical Implications
+
+- Perfect synchronization is unattainable; aim for bounded uncertainty instead.
+- Timeout values must account for drift and network variability.
+- Consensus algorithms rely on logical time to avoid false assumptions about order.
+
+Understanding these limits helps engineers design systems that tolerate ambiguity and favor coordination mechanisms resilient to time's inherent uncertainty.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -350,6 +350,7 @@ nav:
     - Law 5 - Distributed Knowledge: core-principles/laws/distributed-knowledge.md
     - Law 6 - Cognitive Load: core-principles/laws/cognitive-load.md
     - Law 7 - Economic Reality: core-principles/laws/economic-reality.md
+    - Law 8 - Temporal Constraints: core-principles/laws/temporal-constraints.md
     - Interactive Tests:
       - Overview: core-principles/laws/tests/index.md
       - Law 1 Learning Module: core-principles/laws/tests/correlated-failure-test.md


### PR DESCRIPTION
## Summary
- document temporal constraints law on limits of clock sync
- reference temporal constraints from laws overview and navigation
- surface temporal constraints in core principles index and law cards

## Testing
- `mkdocs build >/tmp/mkdocs.log && tail -n 20 /tmp/mkdocs.log`

------
https://chatgpt.com/codex/tasks/task_e_68957f2a225c8326a9ad86638d342a2f