### PR TITLE
Remove duplicate strict setting in MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ repo_url: https://github.com/deepaucksharma/DStudio
 edit_uri: edit/main/docs/
 
 # Enable strict mode for validation
-strict: true
+strict: false
 validation:
   nav:
     omitted_files: warn
@@ -977,7 +977,6 @@ nav:
   - Admonition Guide: reference/admonition-guide.md
   - Recipe Cards: reference/recipe-cards.md
   - Offline Support: reference/offline.md
-strict: false
 use_directory_urls: true
 docs_dir: docs
 site_dir: site


### PR DESCRIPTION
## Summary
- eliminate duplicate `strict` entries in `mkdocs.yml`
- set MkDocs to non-strict mode by default

## Testing
- `mkdocs build --strict` *(fails with many warnings; output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68957ecc432083268d752ffdd047e25f