### PR TITLE
fix: correct comment syntax in offline page

### DIFF
--- a/docs/reference/offline.md
+++ b/docs/reference/offline.md
@@ -53,14 +53,14 @@ hide:
 </div>
 
 <script>
-/ Check connection status periodically
+// Check connection status periodically
 setInterval(() => {
   if (navigator.onLine) {
     window.location.reload();
   }
 }, 5000);
 
-/ Reload when connection is restored
+// Reload when connection is restored
 window.addEventListener('online', () => {
   window.location.reload();
 });


### PR DESCRIPTION
## Summary
- use `//` for comments in offline page's script block

## Testing
- `node - <<'NODE'
const window = {
  location: { reload: () => { console.log('reload called'); } },
  addEventListener: (event, handler) => {
    // no actual events
  }
};
const navigator = { onLine: false };
const timer = setInterval(() => {
  if (navigator.onLine) {
    window.location.reload();
  }
}, 5000);
window.addEventListener('online', () => {
  window.location.reload();
});
clearInterval(timer);
NODE`
- `mkdocs build >/tmp/mkdocs.log && tail -n 20 /tmp/mkdocs.log`


------
https://chatgpt.com/codex/tasks/task_e_68957f17347483268238f444395b29cf