### PR TITLE
Pin docs dependencies and document update process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# DStudio
+
+## Dependency Update Procedure
+
+To update the pinned dependencies used for building the documentation site:
+
+1. Review the desired versions for each package.
+2. Edit `requirements.txt` and adjust the version numbers accordingly.
+3. Install the updated dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Run the pre-commit checks for the modified files:
+   ```bash
+   pre-commit run --files requirements.txt README.md
+   ```
+5. Rebuild the documentation to verify everything works:
+   ```bash
+   mkdocs build
+   ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
-mkdocs>=1.5.3
-mkdocs-material>=9.4.0
-pymdown-extensions>=10.2
-mkdocs-macros-plugin>=1.0.0
-mkdocs-mermaid2-plugin>=1.1.1
-markdown-exec[ansi]>=1.8.0
+mkdocs==1.5.3
+mkdocs-material==9.4.0
+pymdown-extensions==10.2
+mkdocs-macros-plugin==1.0.0
+mkdocs-mermaid2-plugin==1.1.1
+markdown-exec[ansi]==1.8.0
 
 # Performance & SEO Enhancements
-mkdocs-minify-plugin>=0.7.1
-mkdocs-git-revision-date-localized-plugin>=1.2.0
+mkdocs-minify-plugin==0.7.1
+mkdocs-git-revision-date-localized-plugin==1.2.0
+mkdocs-redirects==1.2.0
 
 # Optional Features (uncomment as needed)
-# mkdocs-exclude-search>=0.6.5
-# markdown-include>=0.8.1
-mkdocs-redirects>=1.2.0
-# mkdocs-awesome-pages-plugin>=2.9.0
+# mkdocs-exclude-search==0.6.5
+# markdown-include==0.8.1
+# mkdocs-awesome-pages-plugin==2.9.0


### PR DESCRIPTION
## Summary
- pin all MkDocs-related dependencies to exact versions and tidy optional plugin comments
- add README with instructions for updating dependency versions

## Testing
- `pre-commit run --files requirements.txt README.md` *(fails: can't open scripts/validate-paths.py and scripts/check-broken-links.py)*

------
https://chatgpt.com/codex/tasks/task_e_68957f1d10908326ba56c7f92c2e2f0b