### PR TITLE
Unify project name across config and macros

### DIFF
--- a/docs/macros.py
+++ b/docs/macros.py
@@ -33,7 +33,7 @@ def define_env(env):
     
     # Add variables
     env.variables['current_year'] = datetime.datetime.now().year
-    env.variables['project_name'] = 'The Compendium of Distributed Systems'
+    env.variables['project_name'] = 'Distributed Systems Studio'
     env.variables['github_repo'] = 'https://github.com/deepaucksharma/DStudio'
     
     # Add macros

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: The Compendium of Distributed Systems
+site_name: Distributed Systems Studio
 site_url: https://deepaucksharma.github.io/DStudio/
 site_description: Master distributed systems through physics-derived principles and
   battle-tested patterns


### PR DESCRIPTION
## Summary
- Rename `site_name` in `mkdocs.yml` to **Distributed Systems Studio**
- Update macros `env.variables['project_name']` to use the same unified name

## Testing
- `mkdocs build`
- Verified macros variable via `python docs/macros.py`


------
https://chatgpt.com/codex/tasks/task_e_68957f3176788326a4b597829c6c878d